### PR TITLE
Fix error C2373 with VS2015 update 3

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1686,7 +1686,7 @@ int wmain1(int argc, wchar_t **argv)
         std::string encoder_name;
         encoder_name = strutil::format(PROGNAME " %s", get_qaac_version());
 #ifdef QAAC
-        __pfnDliFailureHook2 = DllImportHook;
+        decltype(__pfnDliNotifyHook2) __pfnDliFailureHook2 = DllImportHook;
         set_dll_directories(opts.verbose);
         HMODULE hDll = LoadLibraryW(L"CoreAudioToolbox.dll");
         if (!hDll)


### PR DESCRIPTION
From delayimp.h:
> // Prior to Visual Studio 2015 Update 3, these hooks were non-const.  They were
> // made const to improve security (global, writable function pointers are bad).
> // If for backwards compatibility you require the hooks to be writable, define
> // the macro DELAYIMP_INSECURE_WRITABLE_HOOKS prior to including this header and
> // provide your own non-const definition of the hooks.