### PR TITLE
Win32InputStream: fix infinite recursion seeking non seekable input

### DIFF
--- a/Win32InputStream.cpp
+++ b/Win32InputStream.cpp
@@ -69,7 +69,9 @@ int64_t Win32InputStream::seek(int64_t off, int whence)
         }
         if (m_eof && m_fd_pos < off)
             return -1;
-        return seek(off, SEEK_SET);
+
+        m_pos = off;
+        return m_pos;
     }
     return seekRaw(off);
 }


### PR DESCRIPTION
<img width="1581" height="1246" alt="test" src="https://github.com/user-attachments/assets/fac71e88-c25b-474b-951f-1df7fba11053" />

Starting with version 2.84, Win32InputStream code was added, and there was an issue where infinite recursion occurred when using raw mode and inputting a stream via stdin.

The testing method is as follows.

(This is a simplified command based on the structure used in foobar2000 + foo_streamer)

I would appreciate it if you could please review the modified code.

```
type test.wav | vcproject\x64\Debug\qaac64.exe --raw --adts -V 127 -o test.m4a - 
```